### PR TITLE
Adding a method to kill chrome process and all it's children.

### DIFF
--- a/ChromeHtmlToPdfLib/ChromeHtmlToPdfLib.csproj
+++ b/ChromeHtmlToPdfLib/ChromeHtmlToPdfLib.csproj
@@ -42,6 +42,7 @@
       <HintPath>..\packages\System.Collections.Specialized.4.3.0\lib\net46\System.Collections.Specialized.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Net.NameResolution, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.NameResolution.4.3.0\lib\net46\System.Net.NameResolution.dll</HintPath>
     </Reference>

--- a/ChromeHtmlToPdfLib/Converter.cs
+++ b/ChromeHtmlToPdfLib/Converter.cs
@@ -180,7 +180,7 @@ namespace ChromeHtmlToPdfLib
         ///     Raised when the <paramref name="userProfile" /> directory is given but
         ///     does not exists
         /// </exception>
-        public Converter(string chromeExeFileName = null, 
+        public Converter(string chromeExeFileName = null,
                          PortRangeSettings portRange = null,
                          string userProfile = null,
                          Stream logStream = null)
@@ -735,9 +735,9 @@ namespace ChromeHtmlToPdfLib
         /// <param name="waitForWindowsStatusTimeout"></param>
         /// <returns>The filename with full path to the generated PDF</returns>
         /// <exception cref="DirectoryNotFoundException"></exception>
-        public void ConvertToPdf(Uri inputUri, 
-                                string outputFile, 
-                                PageSettings pageSettings, 
+        public void ConvertToPdf(Uri inputUri,
+                                string outputFile,
+                                PageSettings pageSettings,
                                 bool waitForNetworkIdle,
                                 string waitForWindowStatus = "",
                                 int waitForWindowsStatusTimeout = 60000)
@@ -830,7 +830,8 @@ namespace ChromeHtmlToPdfLib
                 if (_chromeProcess == null) return;
                 _chromeProcess.Refresh();
                 if (_chromeProcess.HasExited) return;
-                KillProcessAndChildren(_chromeProcess.Id);
+                var logs = KillProcessAndChildren(_chromeProcess.Id);
+                WriteToLog(logs);
                 _chromeProcess = null;
                 WriteToLog("Chrome stopped");
             }


### PR DESCRIPTION
Instead of _chromeProcess.Kill() I added a new method that kills the given process by id, and it's children.

Using this method, there are no orphan Chrome processes left after generating the PDF.

It also works in IIS, using embedded portable chrome, and under AppPool Identity.