### PR TITLE
Migrate .NET Core to 3.0 & use native Kill function to kill whole tree of Chrome processes

### DIFF
--- a/ChromeHtmlToPdfLib/ChromeHtmlToPdfLib.csproj
+++ b/ChromeHtmlToPdfLib/ChromeHtmlToPdfLib.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.26</Version>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <Version>3.0.0</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>ChromeHtmlToPdf is a 100% managed C# .NETStandard 2.0 library that can be used to convert HTML to PDF format with the use of Google Chrome</Description>
     <Copyright>(C)2017-2020 Kees van Spelde</Copyright>

--- a/ChromeHtmlToPdfLib/Converter.cs
+++ b/ChromeHtmlToPdfLib/Converter.cs
@@ -1273,30 +1273,10 @@ namespace ChromeHtmlToPdfLib
         {
             if (processId == 0) return;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                KillProcess(processId);
-                return;
-            }
-
-            using (var managedObjects = new ManagementObjectSearcher($"Select * From Win32_Process Where ParentProcessID={processId}").Get())
-            {
-                if (managedObjects.Count > 0)
-                {
-                    foreach (var managedObject in managedObjects)
-                        KillProcessAndChildren(Convert.ToInt32(managedObject["ProcessID"]));
-                }
-
-                KillProcess(processId);
-            }
-        }
-
-        private void KillProcess(int processId)
-        {
             try
             {
                 var process = Process.GetProcessById(processId);
-                process.Kill();
+                process.Kill(true);
             }
             catch (Exception exception)
             {

--- a/ChromeHtmlToPdfLib/Converter.cs
+++ b/ChromeHtmlToPdfLib/Converter.cs
@@ -1273,6 +1273,12 @@ namespace ChromeHtmlToPdfLib
         {
             if (processId == 0) return;
 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                KillProcess(processId);
+                return;
+            }
+
             using (var managedObjects = new ManagementObjectSearcher($"Select * From Win32_Process Where ParentProcessID={processId}").Get())
             {
                 if (managedObjects.Count > 0)
@@ -1281,16 +1287,21 @@ namespace ChromeHtmlToPdfLib
                         KillProcessAndChildren(Convert.ToInt32(managedObject["ProcessID"]));
                 }
 
-                try
-                {
-                    var process = Process.GetProcessById(processId);
-                    process.Kill();
-                }
-                catch (Exception exception)
-                {
-                    if (!exception.Message.Contains("is not running"))
-                        WriteToLog(exception.Message);
-                }
+                KillProcess(processId);
+            }
+        }
+
+        private void KillProcess(int processId)
+        {
+            try
+            {
+                var process = Process.GetProcessById(processId);
+                process.Kill();
+            }
+            catch (Exception exception)
+            {
+                if (!exception.Message.Contains("is not running"))
+                    WriteToLog(exception.Message);
             }
         }
         #endregion


### PR DESCRIPTION
The ManagementObjectSearcher object is not available on Linux, therefore the exception is thrown and no processes are killed when you run the project on Linux environment. 
I migrated the project to .NET Core 3.0 and therefore used new native Kill() function overload which let us kill the whole tree of process - it is cross platform now.