### PR TITLE
Very basic ILogger Implementation

### DIFF
--- a/ChromeHtmlToPdfLib/ChromeHtmlToPdfLib.csproj
+++ b/ChromeHtmlToPdfLib/ChromeHtmlToPdfLib.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="AngleSharp.Io" Version="0.15.0" />
     <PackageReference Include="AngleSharp.Xml" Version="0.15.0" />
     <PackageReference Include="HtmlSanitizer" Version="5.0.404" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />


### PR DESCRIPTION
Related to #54

This is a very simple start. The class does not really have log levels or otherwise many logging semantics with scopes etc. So for now it dumps everything into Information.

If you use Serilog you can use it as:
```cs
var loggerProvider = new SerilogLoggerProvider(Log); // This wraps your Serilog ILogger into a M.E.L ILogger
var pdfConverter = new Converter(logger: loggerProvider.CreateLogger(nameof(Converter)));
```

To get a SourceContext of "Converter".

The class could also use a static ILogger and render it to the stream if it's there. It might result is a much more usable logging experience overall.

